### PR TITLE
Feature: Add a "how to contribute to the doc" guide

### DIFF
--- a/docs/documentation-docs/configuration.md
+++ b/docs/documentation-docs/configuration.md
@@ -2,7 +2,7 @@
 layout: default
 title: Configuration
 parent: Documentation configuration
-nav_order: 2
+nav_order: 3
 ---
 
 # Configuration

--- a/docs/documentation-docs/help.md
+++ b/docs/documentation-docs/help.md
@@ -1,11 +1,10 @@
 ---
-title: Maintaining the Administration documentation
+title: Maintaining the  documentation
 layout: default
 summary: Key things to know about maintaining this documentation
 status: Needs revision
-parent: Administration Guide
-permalink: /administration/help
-nav_order: 5
+parent: Documentation configuration
+nav_order: 2
 ---
 
 # Introduction

--- a/docs/documentation-docs/how-to-contribute-doc.md
+++ b/docs/documentation-docs/how-to-contribute-doc.md
@@ -18,7 +18,7 @@ This page describes straightforwardly on how to edit and contribute to this docu
 
 ### Click on "edit this page"
 
-At the bottom of each page, you will find a link that will take you to the correspond [markdown](https://docs.github.com/fr/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) file
+At the bottom of each page, you will find a link that will take you to the corresponding [markdown](https://docs.github.com/fr/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) file
 ![image](https://user-images.githubusercontent.com/29259906/206400372-98e8eebd-6964-4f7a-be4e-6025feb64c5b.png)
 
 ### Edit the page
@@ -28,13 +28,13 @@ At the bottom of each page, you will find a link that will take you to the corre
 
 ![image](https://user-images.githubusercontent.com/29259906/206402418-b2bbe74c-0052-4c1f-8e36-10c3a503c621.png)
 
-## How to edit/contribute to an existent pull request
+## How to edit/contribute to an existing pull request
 
 ### Click on "File changed"
 ![image](https://user-images.githubusercontent.com/29259906/207830475-eba783b8-2d9c-4133-abac-422792143cbf.png)
 
-### Scroll to the file you want to edit  and click on the edit button
+### Scroll to the file you want to edit and click on the edit button
 ![image](https://user-images.githubusercontent.com/29259906/207830907-a091d47c-5669-4903-ab36-4dd06662640a.png)
 
-### Do your change and submit a commit
+### Make your change and submit a commit
 ![image](https://user-images.githubusercontent.com/29259906/207832629-ba36a90d-376e-4705-ab10-b3513eec0660.png)

--- a/docs/documentation-docs/how-to-contribute-doc.md
+++ b/docs/documentation-docs/how-to-contribute-doc.md
@@ -1,0 +1,40 @@
+---
+title: How to contribute to the doc
+layout: default
+summary: A guide on how to contribute to this documentation
+status: Needs revision
+parent: Documentation configuration
+nav_order: 1
+---
+
+
+
+This page describes straightforwardly on how to edit and contribute to this documentation
+
+1. TOC
+{:toc}
+
+## How to edit a page
+
+### Click on "edit this page"
+
+At the bottom of each page, you will find a link that will take you to the correspond [markdown](https://docs.github.com/fr/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) file
+![image](https://user-images.githubusercontent.com/29259906/206400372-98e8eebd-6964-4f7a-be4e-6025feb64c5b.png)
+
+### Edit the page
+![image](https://user-images.githubusercontent.com/29259906/206401353-de8808b2-e58a-4405-bb34-8241dfcc3414.png)
+
+### Create a pull request
+
+![image](https://user-images.githubusercontent.com/29259906/206402418-b2bbe74c-0052-4c1f-8e36-10c3a503c621.png)
+
+## How to edit/contribute to an existent pull request
+
+### Click on "File changed"
+![image](https://user-images.githubusercontent.com/29259906/207830475-eba783b8-2d9c-4133-abac-422792143cbf.png)
+
+### Scroll to the file you want to edit  and click on the edit button
+![image](https://user-images.githubusercontent.com/29259906/207830907-a091d47c-5669-4903-ab36-4dd06662640a.png)
+
+### Do your change and submit a commit
+![image](https://user-images.githubusercontent.com/29259906/207832629-ba36a90d-376e-4705-ab10-b3513eec0660.png)

--- a/docs/documentation-docs/index.md
+++ b/docs/documentation-docs/index.md
@@ -4,6 +4,7 @@ title: Documentation configuration
 nav_order: 3
 has_children: true
 permalink: /configuration
+nav_exclude: true
 ---
 
 # How to configure the documentation

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,13 +43,11 @@ View our [Code of Conduct](https://github.com/ncbo/bioportal-project/blob/master
 
 This site uses [Just the Docs] for its template.
 
-If [Jekyll] is installed on your computer, you can build and preview the created site *locally*. This lets you test changes before committing them, and avoids waiting for GitHub Pages.[^2] And you will be able to deploy your local build to a different platform than GitHub Pages.
+If [Jekyll] is installed on your computer, you can build and preview the created site *locally*. This lets you test changes before committing them, and avoids waiting for GitHub Pages. And you will be able to deploy your local build to a different platform than GitHub Pages.
+
+See the [How to configure the documentation](configuration), to find key things to know about maintaining and contributing to this documentation 
 
 ----
-
-[^1]: The [source file for this page] uses all three markup languages.
-
-[^2]: [It can take up to 10 minutes for changes to your site to publish after you push the changes to GitHub](https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/creating-a-github-pages-site-with-jekyll#creating-your-site).
 
 [Jekyll]: https://jekyllrb.com
 [Markdown]: https://daringfireball.net/projects/markdown/


### PR DESCRIPTION
### Context
See https://github.com/ontoportal/administration/issues/11

This PR adds a naive guide (just guided screenshots) of how to edit/contribute to this documentation, open for anyone who wants to consolidate it and make it more readable (redaction is not my strength)  

### Changes 

- Add a How to contribute to the doc page(https://github.com/ontoportal/administration/commit/05c84c120a7e6ea576aa3b60b6a04296284243d3)
- Move the old maintaining doc to the Configuration section(https://github.com/ontoportal/administration/commit/51f28649f27fac8a1cd51416a764e403ddf14f53)
- Don't display configuration docs in the sections tree (https://github.com/ontoportal/administration/pull/18/commits/620a8418e771aeb34c9a55c10b300827a98feb16)
 
![image](https://user-images.githubusercontent.com/29259906/212832571-a879a86e-3f6e-4919-bc12-abc5895d168c.png)

- Reference to the  configuration docs in the home (https://github.com/ontoportal/administration/pull/18/commits/7deb12522b3094dcf3275e645647599b6c9d4ec0)
![image](https://user-images.githubusercontent.com/29259906/212832696-ae6e5d75-4509-4ef0-8cbd-f3aa32e8a86b.png)



### Preview
https://ontoportal-lirmm.github.io/documentation/docs/documentation-docs/how-to-contribute-doc/