### PR TITLE
Fix: Developers environments documentation no showing 

### DIFF
--- a/docs/developers-docs/development-environment/backend_environment.md
+++ b/docs/developers-docs/development-environment/backend_environment.md
@@ -4,7 +4,7 @@ summary: A guide of how to run a development environment for the backend
 layout: default
 status: Draft
 parent:  Development Environment
-grand_parent: Developers Guide
+grand_parent: Developer Guide
 nav_order: 2
 ---
 

--- a/docs/developers-docs/development-environment/frontend_environment.md
+++ b/docs/developers-docs/development-environment/frontend_environment.md
@@ -4,7 +4,7 @@ summary: A guide of how to run a development environment for the frontend
 layout: default
 status: Draft
 parent:  Development Environment
-grand_parent: Developers Guide
+grand_parent: Developer Guide
 nav_order: 1
 ---
 

--- a/docs/developers-docs/development-environment/index.md
+++ b/docs/developers-docs/development-environment/index.md
@@ -3,7 +3,7 @@ title: Development Environment
 summary: Set up a development environment for your own Ontoportal installation
 layout: default
 status: Draft
-parent: Developers Guide
+parent: Developer Guide
 has_children: true
 nav_order: 3
 ---


### PR DESCRIPTION
After this change https://github.com/ontoportal/documentation/commit/98a09a010f38ba139c86e727d386e0083977fb4b made by @jonquet.

The Developer's environments documentation no more showed, because of a miss configuration after the section title change  

This PR fix that.