### PR TITLE
correct config env filepath?

### DIFF
--- a/docs/administration-guide/installation/initial_configuration.md
+++ b/docs/administration-guide/installation/initial_configuration.md
@@ -33,7 +33,7 @@ To start, since you don't have any non-administration accounts, you can add an o
 
 To let the system send emails for lost passwords, notes, and ontology processing reports, 
 you need to provide a valid mail server (smtp) configuration. 
-The configuration should be provided in the `/srv/ncbo/ontologies_api/current/config/environments/production.rb` file.
+The configuration should be provided in the `/srv/ontoportal/ontologies_api/current/config/environments/appliance.rb` file.
 
 Here are the available settings:
 


### PR DESCRIPTION
```
[centos@ip-xxx-xx-xx-xxx ~]$ sudo ls /srv
ontoportal  tomcat

[centos@ip-xxx-xx-xx-xxx ~]$ sudo ls /srv/ontoportal/ontologies_api/current/config/environments/
appliance.rb  appliance.rb.default  config.rb.sample  site_config.rb  test.rb
```

The above is what I see on my AWS AMI instance. Is my guess at the filepath correct?